### PR TITLE
[#6] 제품, 카테고리 Entity, Repository 생성

### DIFF
--- a/src/main/java/flab/rocket_market/entity/Categories.java
+++ b/src/main/java/flab/rocket_market/entity/Categories.java
@@ -1,0 +1,23 @@
+package flab.rocket_market.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Categories {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+}

--- a/src/main/java/flab/rocket_market/entity/Products.java
+++ b/src/main/java/flab/rocket_market/entity/Products.java
@@ -1,6 +1,7 @@
 package flab.rocket_market.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import flab.rocket_market.global.util.ValueUtils;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -43,9 +44,9 @@ public class Products {
     private LocalDateTime updatedAt;
 
     public void updateProduct(String name, String description, BigDecimal price, Categories category) {
-        this.name = name == null || name.isEmpty() ? this.name : name;
-        this.description = description == null ? this.description : description;
-        this.price = price == null ? this.price : price;
-        this.category = category == null ? this.category : category;
+        this.name = ValueUtils.getNonNullValue(name, this.name);
+        this.description = ValueUtils.getNonNullValue(description, this.description);
+        this.price = ValueUtils.getNonNullValue(price, this.price);
+        this.category = ValueUtils.getNonNullValue(category, this.category);
     }
 }

--- a/src/main/java/flab/rocket_market/entity/Products.java
+++ b/src/main/java/flab/rocket_market/entity/Products.java
@@ -1,0 +1,44 @@
+package flab.rocket_market.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Products {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long productId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(precision = 10, scale = 2)
+    private BigDecimal price;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private Categories category;
+
+    @CreatedDate
+    @Column(updatable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/flab/rocket_market/entity/Products.java
+++ b/src/main/java/flab/rocket_market/entity/Products.java
@@ -41,4 +41,11 @@ public class Products {
     @LastModifiedDate
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
+
+    public void updateProduct(String name, String description, BigDecimal price, Categories category) {
+        this.name = name == null || name.isEmpty() ? this.name : name;
+        this.description = description == null ? this.description : description;
+        this.price = price == null ? this.price : price;
+        this.category = category == null ? this.category : category;
+    }
 }

--- a/src/main/java/flab/rocket_market/global/util/ValueUtils.java
+++ b/src/main/java/flab/rocket_market/global/util/ValueUtils.java
@@ -1,0 +1,7 @@
+package flab.rocket_market.global.util;
+
+public class ValueUtils {
+    public static <T> T getNonNullValue(T newValue, T oldValue) {
+        return newValue == null || (newValue instanceof String && ((String) newValue).isEmpty()) ? oldValue : newValue;
+    }
+}

--- a/src/main/java/flab/rocket_market/repository/CategoryRepository.java
+++ b/src/main/java/flab/rocket_market/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package flab.rocket_market.repository;
+
+import flab.rocket_market.entity.Categories;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Categories, Long> {
+}

--- a/src/main/java/flab/rocket_market/repository/ProductRepository.java
+++ b/src/main/java/flab/rocket_market/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package flab.rocket_market.repository;
+
+import flab.rocket_market.entity.Products;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Products, Long> {
+}


### PR DESCRIPTION
## PR 개요
제품 CRUD를 위한 Entity, Repository 추가

## 🔨 변경 내용
- Entity 생성
  - Categories 
  - Products

- Repository 생성
  - CategoryRepository
  - ProductRepository

## 📌 Issues
- Entity에서의 업데이트 메서드 사용 
Products Entity의 특정 필드만 변경하고 나머지 필드는 그대로 유지하기 위한 메서드 추가 (updateProduct)