### PR TITLE
[#9] 사용자 정의 예외 생성

### DIFF
--- a/src/main/java/flab/rocket_market/exception/CategoryNotFoundException.java
+++ b/src/main/java/flab/rocket_market/exception/CategoryNotFoundException.java
@@ -7,7 +7,7 @@ public class CategoryNotFoundException extends RocketMarketException {
 
     public static final CategoryNotFoundException EXCEPTION = new CategoryNotFoundException();
 
-    public CategoryNotFoundException() {
+    private CategoryNotFoundException() {
         super(CategoryErrorProperty.CATEGORY_NOT_FOUND);
     }
 }

--- a/src/main/java/flab/rocket_market/exception/CategoryNotFoundException.java
+++ b/src/main/java/flab/rocket_market/exception/CategoryNotFoundException.java
@@ -1,0 +1,13 @@
+package flab.rocket_market.exception;
+
+import flab.rocket_market.exception.error.CategoryErrorProperty;
+import flab.rocket_market.global.exception.RocketMarketException;
+
+public class CategoryNotFoundException extends RocketMarketException {
+
+    public static final CategoryNotFoundException EXCEPTION = new CategoryNotFoundException();
+
+    public CategoryNotFoundException() {
+        super(CategoryErrorProperty.CATEGORY_NOT_FOUND);
+    }
+}

--- a/src/main/java/flab/rocket_market/exception/ProductNotFoundException.java
+++ b/src/main/java/flab/rocket_market/exception/ProductNotFoundException.java
@@ -1,0 +1,13 @@
+package flab.rocket_market.exception;
+
+import flab.rocket_market.exception.error.ProductErrorProperty;
+import flab.rocket_market.global.exception.RocketMarketException;
+
+public class ProductNotFoundException extends RocketMarketException {
+
+    public static final ProductNotFoundException EXCEPTION = new ProductNotFoundException();
+
+    public ProductNotFoundException() {
+        super(ProductErrorProperty.PRODUCT_NOTFOUNTD_EXCEPTION);
+    }
+}

--- a/src/main/java/flab/rocket_market/exception/ProductNotFoundException.java
+++ b/src/main/java/flab/rocket_market/exception/ProductNotFoundException.java
@@ -7,7 +7,7 @@ public class ProductNotFoundException extends RocketMarketException {
 
     public static final ProductNotFoundException EXCEPTION = new ProductNotFoundException();
 
-    public ProductNotFoundException() {
+    private ProductNotFoundException() {
         super(ProductErrorProperty.PRODUCT_NOTFOUNTD_EXCEPTION);
     }
 }

--- a/src/main/java/flab/rocket_market/exception/error/CategoryErrorProperty.java
+++ b/src/main/java/flab/rocket_market/exception/error/CategoryErrorProperty.java
@@ -1,0 +1,16 @@
+package flab.rocket_market.exception.error;
+
+import flab.rocket_market.global.exception.error.ErrorProperty;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryErrorProperty implements ErrorProperty {
+
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리가 존재하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/flab/rocket_market/exception/error/ProductErrorProperty.java
+++ b/src/main/java/flab/rocket_market/exception/error/ProductErrorProperty.java
@@ -1,0 +1,16 @@
+package flab.rocket_market.exception.error;
+
+import flab.rocket_market.global.exception.error.ErrorProperty;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductErrorProperty implements ErrorProperty {
+
+    PRODUCT_NOTFOUNTD_EXCEPTION(HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}


### PR DESCRIPTION
## PR 개요
제품, 카테고리 ID로 조회 시, 해당 값이 NULL인 경우 발생하는 사용자 정의 예외 추가

## 🔨 변경 내용
- 상수 정의
  - CategoryErrorProperty 
  - ProductErrorProperty 
- 사용자 정의 예외 생성
  - RocketMarketException을 상속
  - 예외 속성 전달 (생성자 파라미터에 미리 정의한 상수를 전달하여 상태 코드와 메시지를 설정)
  - 싱글톤 패턴 적용

## 📌 Issues
- 싱글톤 패턴 적용 이유
  - 싱글톤 패턴은 상태가 변하지 않거나 내부적으로 관리할 상태가 없는 객체에 적합
  - 메모리 효율성과 성능 개선
  - 코드의 간결함