### PR TITLE
[#17] OpenAPI spec 적용 (1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,10 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.2'
 	id 'io.spring.dependency-management' version '1.1.6'
+	// epages-restdocs 플러그인 추가
+	id 'com.epages.restdocs-api-spec' version '0.18.4'
+	// swagger generator 플러그인 추가
+	id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'flab'
@@ -23,6 +27,11 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	// snippetsDirectory 설정
+	snippetsDir = file('build/generated-snippets')
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -31,8 +40,45 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	// Spring REST Docs 의존성
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	// epages REST Docs 의존성
+	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.4'
+	// Swagger 의존성
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.withType(GenerateSwaggerUI) {
+	// openapi3 테스크 이후에 실행 됨
+	dependsOn 'openapi3'
+
+	// 기존 파일 삭제
+	delete file('src/main/resources/static/docs/')
+
+	// 빌드된 JSON 파일을 복사
+	copy {
+		from "build/resources/main/static/docs"
+		into "src/main/resources/static/docs/"
+	}
+}
+
+openapi3 {
+	servers = [
+			{ url = 'http://localhost:8080' }
+	]
+	title = 'Rocket Market API'
+	description = 'Rocket Market API'
+	version = '0.0.1'
+	outputFileNamePrefix = 'rocket-market-api - 0.0.1'
+	format = 'json'
+
+	outputDirectory = 'build/resources/main/static/docs'
+}
+
+bootJar {
+	dependsOn(':openapi3')
 }

--- a/src/main/java/flab/rocket_market/controller/ProductController.java
+++ b/src/main/java/flab/rocket_market/controller/ProductController.java
@@ -18,9 +18,9 @@ public class ProductController {
     private final ProductService productService;
 
     @PostMapping
-    public BaseResponse registerProduct(@RequestBody RegisterProductRequest productRequest) {
-        productService.registerProduct(productRequest);
-        return BaseResponse.of(HttpStatus.CREATED, "성공적으로 등록되었습니다.");
+    public BaseDataResponse<ProductResponse> registerProduct(@RequestBody RegisterProductRequest productRequest) {
+        ProductResponse product = productService.registerProduct(productRequest);
+        return BaseDataResponse.of(HttpStatus.CREATED, "성공적으로 등록되었습니다.", product);
     }
 
     @GetMapping("/{productId}")

--- a/src/main/java/flab/rocket_market/service/ProductService.java
+++ b/src/main/java/flab/rocket_market/service/ProductService.java
@@ -22,7 +22,7 @@ public class ProductService {
     private final CategoryRepository categoryRepository;
     private final ProductRepository productRepository;
 
-    public void registerProduct(RegisterProductRequest productRequest) {
+    public ProductResponse registerProduct(RegisterProductRequest productRequest) {
         Categories category = getCategory(productRequest.getCategoryId());
 
         Products product = Products.builder()
@@ -32,7 +32,9 @@ public class ProductService {
                 .category(category)
                 .build();
 
-        productRepository.save(product);
+        Products savedProduct = productRepository.save(product);
+
+        return ProductResponse.of(savedProduct);
     }
 
     public ProductResponse getProductById(Long productId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,8 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
     generate-ddl: true
+
+springdoc:
+  swagger-ui:
+    url: /docs/rocket-market-api - 0.0.1.json
+    path: /docs/swagger


### PR DESCRIPTION
## PR 개요
build.gradle 의존성 및 Swagger + Spring REST Docs 설정 추가

## 🔨 변경 내용
- registerProduct 메서드 리턴 값 추가 (ProductResponse)
- 의존성 및 설정 추가
  - Spring REST Docs (spring-restdocs-mockmvc): MockMvc를 사용하며 API 문서를 테스트와 함께 자동으로 생성
  - ePages REST Docs (restdocs-api-spec-mockmvc): Spring REST Docs의 스니펫을 OpenAPI 문서로 변환
  - Swagger(OpenAPI) (springdoc-openapi-starter-webmvc-ui): OpenAPI 문서를 자동으로 생성하고, Swagger UI를 통해 시각화
- applicarion.yml 에 Swagger 관련 설정 추가

## 📌 Issues
- Swagger과 Spring REST Docs 를 함께 사용한 이유
  - Swagger은 API 문서가 자동으로 생성되고, 화면에서 API를 직접 호출하여 테스트가 가능하다.
  하지만 프로덕션 코드에 문서화를 위한 코드가 포함되고, 검증되지 않은 API가 생성될 수 있다.
  - Spring Rest Docs는 테스트 통과 후 API 문서가 생성되고, 비즈니스 로직에는 API 문서 관련 코드가 없다. 하지만 API Test 기능이 지원되지 않는다.
