### PR TITLE
[#32] 유효성 검사 및 Message Constants 추가 (3)

### DIFF
--- a/src/main/java/flab/rocket_market/controller/ProductController.java
+++ b/src/main/java/flab/rocket_market/controller/ProductController.java
@@ -6,9 +6,12 @@ import flab.rocket_market.controller.dto.UpdateProductRequest;
 import flab.rocket_market.global.response.BaseDataResponse;
 import flab.rocket_market.global.response.BaseResponse;
 import flab.rocket_market.service.ProductService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import static flab.rocket_market.global.message.MessageConstants.*;
 
 @RestController
 @RequestMapping("/products")
@@ -18,26 +21,27 @@ public class ProductController {
     private final ProductService productService;
 
     @PostMapping
-    public BaseDataResponse<ProductResponse> registerProduct(@RequestBody RegisterProductRequest productRequest) {
+    public BaseDataResponse<ProductResponse> registerProduct(@Valid @RequestBody RegisterProductRequest productRequest) {
         ProductResponse product = productService.registerProduct(productRequest);
-        return BaseDataResponse.of(HttpStatus.CREATED, "성공적으로 등록되었습니다.", product);
+        return BaseDataResponse.of(HttpStatus.CREATED, PRODUCT_REGISTER_SUCCESS.getMessage(), product);
     }
 
     @GetMapping("/{productId}")
     public BaseDataResponse<ProductResponse> getProductById(@PathVariable("productId") Long productId) {
         ProductResponse product = productService.getProductById(productId);
-        return BaseDataResponse.of(HttpStatus.OK, "성공적으로 조회되었습니다.", product);
+        return BaseDataResponse.of(HttpStatus.OK, PRODUCT_RETRIEVE_SUCCESS.getMessage(), product);
     }
 
     @PatchMapping
-    public BaseResponse updateProduct(@RequestBody UpdateProductRequest productRequest) {
+    public BaseResponse updateProduct(@Valid @RequestBody UpdateProductRequest productRequest) {
         productService.updateProduct(productRequest);
-        return BaseResponse.of(HttpStatus.OK, "성공적으로 수정되었습니다.");
+        return BaseResponse.of(HttpStatus.OK, PRODUCT_UPDATE_SUCCESS.getMessage());
     }
 
     @DeleteMapping("/{productId}")
     public BaseResponse deleteProduct(@PathVariable("productId") Long productId) {
         productService.deleteProduct(productId);
-        return BaseResponse.of(HttpStatus.NO_CONTENT, "성공적으로 삭제되었습니다.");
+        return BaseResponse.of(HttpStatus.NO_CONTENT, PRODUCT_DELETE_SUCCESS.getMessage());
     }
 }
+

--- a/src/main/java/flab/rocket_market/global/exception/RocketMarketExceptionAdvice.java
+++ b/src/main/java/flab/rocket_market/global/exception/RocketMarketExceptionAdvice.java
@@ -1,8 +1,16 @@
 package flab.rocket_market.global.exception;
 
+import flab.rocket_market.global.response.BaseDataResponse;
 import flab.rocket_market.global.response.BaseResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static flab.rocket_market.global.message.MessageConstants.VALIDATION_FAILED;
 
 @RestControllerAdvice
 public class RocketMarketExceptionAdvice {
@@ -10,5 +18,14 @@ public class RocketMarketExceptionAdvice {
     @ExceptionHandler(RocketMarketException.class)
     public BaseResponse handleException(RocketMarketException exception) {
         return BaseResponse.of(exception.getError().getStatus(), exception.getError().getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public BaseDataResponse<Map<String, String>> handleValidationException(MethodArgumentNotValidException exception) {
+        Map<String, String> errors = new HashMap<>();
+        exception.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage())
+        );
+        return BaseDataResponse.of(HttpStatus.BAD_REQUEST, VALIDATION_FAILED.getMessage(), errors);
     }
 }


### PR DESCRIPTION
## PR 개요
유효성 검사 컨트롤러 적용 및 전역예외처리기에 유효성 검사 실패 경우 추가

## 🔨 변경 내용
- 컨트롤러 등록, 수정 로직에 Valid 어노테이션 추가
- String 메시지 상수로 변경
- 유효성 검사 실패 부분 전역예외 처리 추가

## 📌 Issues