### PR TITLE
[#20] 품목 전체 목록 조회 기능 (페이징 적용)

### DIFF
--- a/src/main/java/flab/rocket_market/controller/ProductController.java
+++ b/src/main/java/flab/rocket_market/controller/ProductController.java
@@ -12,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 import static flab.rocket_market.global.message.MessageConstants.*;
 
 @RestController

--- a/src/main/java/flab/rocket_market/controller/ProductController.java
+++ b/src/main/java/flab/rocket_market/controller/ProductController.java
@@ -1,5 +1,6 @@
 package flab.rocket_market.controller;
 
+import flab.rocket_market.controller.dto.PageResponse;
 import flab.rocket_market.controller.dto.ProductResponse;
 import flab.rocket_market.controller.dto.RegisterProductRequest;
 import flab.rocket_market.controller.dto.UpdateProductRequest;
@@ -10,6 +11,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static flab.rocket_market.global.message.MessageConstants.*;
 
@@ -42,6 +45,25 @@ public class ProductController {
     public BaseResponse deleteProduct(@PathVariable("productId") Long productId) {
         productService.deleteProduct(productId);
         return BaseResponse.of(HttpStatus.NO_CONTENT, PRODUCT_DELETE_SUCCESS.getMessage());
+    }
+
+    @GetMapping
+    public BaseDataResponse<PageResponse<ProductResponse>> getProducts(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        PageResponse<ProductResponse> pageResponse = productService.getProducts(page, size);
+        return BaseDataResponse.of(HttpStatus.OK, PRODUCT_RETRIEVE_SUCCESS.getMessage(), pageResponse);
+    }
+
+    @GetMapping("/search")
+    public BaseDataResponse<PageResponse<ProductResponse>> searchProducts(
+            @RequestParam(name = "keyword") String keyword,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        PageResponse<ProductResponse> pageResponse = productService.searchProducts(keyword, page, size);
+        return BaseDataResponse.of(HttpStatus.OK, PRODUCT_RETRIEVE_SUCCESS.getMessage(), pageResponse);
     }
 }
 

--- a/src/main/java/flab/rocket_market/controller/dto/PageResponse.java
+++ b/src/main/java/flab/rocket_market/controller/dto/PageResponse.java
@@ -1,0 +1,18 @@
+package flab.rocket_market.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PageResponse<T> {
+
+    private List<T> content;
+    private int pageNumber;
+    private int pageSize;
+    private long totalElement;
+    private int totalPages;
+    private boolean isLast;
+}

--- a/src/main/java/flab/rocket_market/repository/ProductRepository.java
+++ b/src/main/java/flab/rocket_market/repository/ProductRepository.java
@@ -1,7 +1,17 @@
 package flab.rocket_market.repository;
 
 import flab.rocket_market.entity.Products;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Products, Long> {
+
+    @Override
+    @EntityGraph(attributePaths = "category")
+    Page<Products> findAll(Pageable pageable);
+
+    @EntityGraph(attributePaths = "category")
+    Page<Products> findByNameContaining(String keyword, Pageable pageable);
 }


### PR DESCRIPTION
## PR 개요
품목 리스트 조회 기능, 키워드 검색 기능 추가

## 🔨 변경 내용
- 페이지 관련 정보와 함께 보내기 위한 PageResponse DTO 생성
- 품목 리스트, 키워드 조회 관련 로직 생성
- 테스트 코드 작성

## 📌 Issues
