### PR TITLE
[#48] Elasticsearch 연동 설정 및 인덱스 정보 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/flab/rocket_market/entity/ProductsDocument.java
+++ b/src/main/java/flab/rocket_market/entity/ProductsDocument.java
@@ -1,0 +1,45 @@
+package flab.rocket_market.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 엘라스틱 서치에 사용 되는 인덱스 (관계형 디비 table - 엘라스틱서치 index)
+ * */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+@Setting(settingPath = "/static/elastic/elastic-settings.json")
+@Mapping(mappingPath = "/static/elastic/product-mappings.json")
+@Document(indexName = "products")
+public class ProductsDocument {
+
+    @Id
+    @Field(name = "product_id", type = FieldType.Long)
+    private Long productsId;
+
+    @Field(type = FieldType.Text)
+    private String name;
+
+    @Field(type = FieldType.Text)
+    private String description;
+
+    @Field(type = FieldType.Scaled_Float, scalingFactor = 100)
+    private BigDecimal price;
+
+    @Field(type = FieldType.Text)
+    private String categoryName;
+
+    @Field(name = "createdAt", type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+    private LocalDateTime createdAt;
+
+    @Field(name = "updated_at", type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/flab/rocket_market/global/config/ElasticSearchConfig.java
+++ b/src/main/java/flab/rocket_market/global/config/ElasticSearchConfig.java
@@ -1,0 +1,18 @@
+package flab.rocket_market.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories(basePackages = "org.springframework.data.elasticsearch.repository")
+public class ElasticSearchConfig extends ElasticsearchConfiguration {
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+                .connectedTo("localhost:9200")
+                .build();
+    }
+}

--- a/src/main/resources/static/elastic/elastic-settings.json
+++ b/src/main/resources/static/elastic/elastic-settings.json
@@ -1,0 +1,9 @@
+{
+  "analysis": {
+    "analyzer": {
+      "korean": {
+        "type": "nori"
+      }
+    }
+  }
+}

--- a/src/main/resources/static/elastic/product-mappings.json
+++ b/src/main/resources/static/elastic/product-mappings.json
@@ -1,0 +1,37 @@
+{
+  "properties": {
+
+    "productId": {
+      "type": "keyword"
+    },
+
+    "name": {
+      "type": "text",
+      "analyzer": "korean"
+    },
+
+    "description": {
+      "type": "text",
+      "analyzer": "korean"
+    },
+
+    "price": {
+      "type": "float"
+    },
+
+    "categoryName": {
+      "type": "text",
+      "analyzer": "korean"
+    },
+
+    "createdAt": {
+      "type": "date",
+      "format": "uuuu-MM-dd'T'HH:mm:ss"
+    },
+
+    "updatedAt": {
+      "type": "date",
+      "format": "uuuu-MM-dd'T'HH:mm:ss"
+    }
+  }
+}


### PR DESCRIPTION
## PR 개요
Elasticsearch 사용을 위한 설정 및 인덱스 정보 추가
(인덱스란, Elasticsearch에서 데이터를 저장하고 검색하는 기본 단위이며, 데이터베이스의 테이블과 유사한 개념)

## 🔨 변경 내용
- Elasticsearch 의존성 추가
- 인덱스 관련 클래스 생성
- 인덱스 필드 매핑 정보 파일 추가
- 인덱스 설정 파일 추가

## 📌 Issues