### PR TITLE
[#48] Products Entity 변경 시 Elasticsearch 반영을 위한 리스너 클래스 추가

### DIFF
--- a/src/main/java/flab/rocket_market/document/ProductsDocument.java
+++ b/src/main/java/flab/rocket_market/document/ProductsDocument.java
@@ -1,4 +1,4 @@
-package flab.rocket_market.entity;
+package flab.rocket_market.document;
 
 import lombok.*;
 import org.springframework.data.annotation.Id;

--- a/src/main/java/flab/rocket_market/entity/Products.java
+++ b/src/main/java/flab/rocket_market/entity/Products.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@EntityListeners(ProductsEntityListener.class)
 public class Products {
 
     @Id

--- a/src/main/java/flab/rocket_market/entity/ProductsEntityListener.java
+++ b/src/main/java/flab/rocket_market/entity/ProductsEntityListener.java
@@ -1,0 +1,26 @@
+package flab.rocket_market.entity;
+
+import flab.rocket_market.service.ProductsSearchService;
+import jakarta.persistence.PostPersist;
+import jakarta.persistence.PostRemove;
+import jakarta.persistence.PostUpdate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductsEntityListener {
+
+    @Autowired
+    private ProductsSearchService productsSearchService;
+
+    @PostPersist
+    @PostUpdate
+    public void postPersistOrUpdate(Products products) {
+        productsSearchService.saveProductsToElasticsearch(products);
+    }
+
+    @PostRemove
+    public void postRemove(Products products) {
+        productsSearchService.deleteProductsFromElasticsearch(products.getProductId());
+    }
+}

--- a/src/main/java/flab/rocket_market/repository/ProductsSearchRepository.java
+++ b/src/main/java/flab/rocket_market/repository/ProductsSearchRepository.java
@@ -1,6 +1,6 @@
 package flab.rocket_market.repository;
 
-import flab.rocket_market.entity.ProductsDocument;
+import flab.rocket_market.document.ProductsDocument;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;

--- a/src/main/java/flab/rocket_market/service/ProductsSearchService.java
+++ b/src/main/java/flab/rocket_market/service/ProductsSearchService.java
@@ -3,7 +3,7 @@ package flab.rocket_market.service;
 import flab.rocket_market.dto.PageResponse;
 import flab.rocket_market.dto.ProductResponse;
 import flab.rocket_market.entity.Products;
-import flab.rocket_market.entity.ProductsDocument;
+import flab.rocket_market.document.ProductsDocument;
 import flab.rocket_market.repository.ProductsSearchRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;


### PR DESCRIPTION
## PR 개요
MySql 데이터 추가/수정/삭제 시, Elasticsearch 데이터 동기화를 위한 작업

## 🔨 변경 내용
- ProductsEntityListener 추가
- Products 클래스  EntityListeners 어노테이션 설정
- ProductsDocument 클래스 document 패키지로 위치 이동

## 📌 Issues
