### PR TITLE
[#57] products 관련 클래스 패키지 분리 (1)

### DIFF
--- a/src/main/java/flab/rocket_market/products/controller/ProductController.java
+++ b/src/main/java/flab/rocket_market/products/controller/ProductController.java
@@ -1,13 +1,13 @@
-package flab.rocket_market.controller;
+package flab.rocket_market.products.controller;
 
-import flab.rocket_market.dto.PageResponse;
-import flab.rocket_market.dto.ProductResponse;
-import flab.rocket_market.dto.RegisterProductRequest;
-import flab.rocket_market.dto.UpdateProductRequest;
+import flab.rocket_market.products.dto.PageResponse;
+import flab.rocket_market.products.dto.ProductResponse;
+import flab.rocket_market.products.dto.RegisterProductRequest;
+import flab.rocket_market.products.dto.UpdateProductRequest;
 import flab.rocket_market.global.response.BaseDataResponse;
 import flab.rocket_market.global.response.BaseResponse;
-import flab.rocket_market.service.ProductService;
-import flab.rocket_market.service.ProductsSearchService;
+import flab.rocket_market.products.service.ProductService;
+import flab.rocket_market.products.service.ProductsSearchService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/flab/rocket_market/products/document/ProductsDocument.java
+++ b/src/main/java/flab/rocket_market/products/document/ProductsDocument.java
@@ -1,4 +1,4 @@
-package flab.rocket_market.document;
+package flab.rocket_market.products.document;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/flab/rocket_market/products/dto/PageResponse.java
+++ b/src/main/java/flab/rocket_market/products/dto/PageResponse.java
@@ -1,4 +1,4 @@
-package flab.rocket_market.dto;
+package flab.rocket_market.products.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;

--- a/src/main/java/flab/rocket_market/products/dto/ProductResponse.java
+++ b/src/main/java/flab/rocket_market/products/dto/ProductResponse.java
@@ -1,10 +1,10 @@
-package flab.rocket_market.dto;
+package flab.rocket_market.products.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
-import flab.rocket_market.entity.Products;
+import flab.rocket_market.products.entity.Products;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/flab/rocket_market/products/dto/RegisterProductRequest.java
+++ b/src/main/java/flab/rocket_market/products/dto/RegisterProductRequest.java
@@ -1,4 +1,4 @@
-package flab.rocket_market.dto;
+package flab.rocket_market.products.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;


### PR DESCRIPTION
## PR 개요
products 패키지 생성 후 관련 클래스 이동

## 🔨 변경 내용
- products 패키지 생성 후 관련 클래스 이동

- 최종 변경 후 예상 구조
src/main/java/flab/rocket_market
│
├── products
│   ├── controller
│   ├── service
│   ├── repository
│   ├── dto
│   ├── entity
│   └── exception
│
├── orders
│   ├── controller
│   ├── service
│   ├── repository
│   ├── dto
│   ├── entity
│   └── exception
│
└── users
    ├── controller
    ├── service
    ├── repository
    ├── dto
    ├── entity
    └── exception

## 📌 Issues
