### PR TITLE
[#57] products 관련 클래스 패키지 분리 (4)

### DIFF
--- a/src/main/java/flab/rocket_market/products/repository/CategoryRepository.java
+++ b/src/main/java/flab/rocket_market/products/repository/CategoryRepository.java
@@ -1,6 +1,6 @@
-package flab.rocket_market.repository;
+package flab.rocket_market.products.repository;
 
-import flab.rocket_market.entity.Categories;
+import flab.rocket_market.products.entity.Categories;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Categories, Long> {

--- a/src/main/java/flab/rocket_market/products/repository/ProductRepository.java
+++ b/src/main/java/flab/rocket_market/products/repository/ProductRepository.java
@@ -1,6 +1,6 @@
-package flab.rocket_market.repository;
+package flab.rocket_market.products.repository;
 
-import flab.rocket_market.entity.Products;
+import flab.rocket_market.products.entity.Products;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;

--- a/src/main/java/flab/rocket_market/products/repository/ProductsSearchRepository.java
+++ b/src/main/java/flab/rocket_market/products/repository/ProductsSearchRepository.java
@@ -1,6 +1,6 @@
-package flab.rocket_market.repository;
+package flab.rocket_market.products.repository;
 
-import flab.rocket_market.document.ProductsDocument;
+import flab.rocket_market.products.document.ProductsDocument;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;

--- a/src/main/java/flab/rocket_market/products/service/ProductService.java
+++ b/src/main/java/flab/rocket_market/products/service/ProductService.java
@@ -1,16 +1,16 @@
-package flab.rocket_market.service;
+package flab.rocket_market.products.service;
 
 import flab.rocket_market.aop.RequiredRole;
-import flab.rocket_market.dto.PageResponse;
-import flab.rocket_market.dto.ProductResponse;
-import flab.rocket_market.dto.RegisterProductRequest;
-import flab.rocket_market.dto.UpdateProductRequest;
-import flab.rocket_market.entity.Categories;
-import flab.rocket_market.entity.Products;
-import flab.rocket_market.exception.CategoryNotFoundException;
-import flab.rocket_market.exception.ProductNotFoundException;
-import flab.rocket_market.repository.CategoryRepository;
-import flab.rocket_market.repository.ProductRepository;
+import flab.rocket_market.products.dto.PageResponse;
+import flab.rocket_market.products.dto.ProductResponse;
+import flab.rocket_market.products.dto.RegisterProductRequest;
+import flab.rocket_market.products.dto.UpdateProductRequest;
+import flab.rocket_market.products.entity.Categories;
+import flab.rocket_market.products.entity.Products;
+import flab.rocket_market.products.exception.CategoryNotFoundException;
+import flab.rocket_market.products.exception.ProductNotFoundException;
+import flab.rocket_market.products.repository.CategoryRepository;
+import flab.rocket_market.products.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;

--- a/src/main/java/flab/rocket_market/products/service/ProductsSearchService.java
+++ b/src/main/java/flab/rocket_market/products/service/ProductsSearchService.java
@@ -1,10 +1,10 @@
-package flab.rocket_market.service;
+package flab.rocket_market.products.service;
 
-import flab.rocket_market.dto.PageResponse;
-import flab.rocket_market.dto.ProductResponse;
-import flab.rocket_market.entity.Products;
-import flab.rocket_market.document.ProductsDocument;
-import flab.rocket_market.repository.ProductsSearchRepository;
+import flab.rocket_market.products.dto.PageResponse;
+import flab.rocket_market.products.dto.ProductResponse;
+import flab.rocket_market.products.entity.Products;
+import flab.rocket_market.products.document.ProductsDocument;
+import flab.rocket_market.products.repository.ProductsSearchRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;


### PR DESCRIPTION
## PR 개요
products 패키지 생성 후 관련 클래스 이동

## 🔨 변경 내용
- products 패키지 생성 후 관련 클래스 이동

- 최종 변경 후 예상 구조
src/main/java/flab/rocket_market
│
├── products
│ ├── controller
│ ├── service
│ ├── repository
│ ├── dto
│ ├── entity
│ └── exception
│
├── orders
│ ├── controller
│ ├── service
│ ├── repository
│ ├── dto
│ ├── entity
│ └── exception
│
└── users
├── controller
├── service
├── repository
├── dto
├── entity
└── exception

## 📌 Issues
