### PR TITLE
[#57] users 관련 클래스 패키지 분리 (1)

### DIFF
--- a/src/main/java/flab/rocket_market/users/dto/User.java
+++ b/src/main/java/flab/rocket_market/users/dto/User.java
@@ -1,4 +1,4 @@
-package flab.rocket_market.dto;
+package flab.rocket_market.users.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/flab/rocket_market/users/entity/Users.java
+++ b/src/main/java/flab/rocket_market/users/entity/Users.java
@@ -1,0 +1,40 @@
+package flab.rocket_market.users.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Users {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(unique = true, nullable = false, length = 50)
+    private String username;
+
+    @Column(nullable = false, length = 255)
+    private String password;
+
+    @Column(unique = true, nullable = false, length = 100)
+    private String email;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/flab/rocket_market/users/exception/error/SecurityErrorProperty.java
+++ b/src/main/java/flab/rocket_market/users/exception/error/SecurityErrorProperty.java
@@ -1,4 +1,4 @@
-package flab.rocket_market.exception.error;
+package flab.rocket_market.users.exception.error;
 
 import flab.rocket_market.global.exception.error.ErrorProperty;
 import lombok.Getter;

--- a/src/main/java/flab/rocket_market/users/repository/UserRepository.java
+++ b/src/main/java/flab/rocket_market/users/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package flab.rocket_market.users.repository;
+
+import flab.rocket_market.users.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<Users, Long> {
+}

--- a/src/main/java/flab/rocket_market/users/service/UserService.java
+++ b/src/main/java/flab/rocket_market/users/service/UserService.java
@@ -1,6 +1,6 @@
-package flab.rocket_market.service;
+package flab.rocket_market.users.service;
 
-import flab.rocket_market.dto.User;
+import flab.rocket_market.users.dto.User;
 import org.springframework.stereotype.Service;
 
 @Service


### PR DESCRIPTION
## PR 개요
users 패키지 생성 후 관련 클래스 이동

## 🔨 변경 내용
- users 패키지 생성 후 관련 클래스 이동

- 최종 변경 후 예상 구조
src/main/java/flab/rocket_market
│
├── products
│ ├── controller
│ ├── service
│ ├── repository
│ ├── dto
│ ├── entity
│ └── exception
│
├── orders
│ ├── controller
│ ├── service
│ ├── repository
│ ├── dto
│ ├── entity
│ └── exception
│
└── users
├── controller
├── service
├── repository
├── dto
├── entity
└── exception

## 📌 Issues