### PR TITLE
[#57] users 관련 클래스 패키지 분리 (2)

### DIFF
--- a/src/main/java/flab/rocket_market/aop/AuthorizationAspect.java
+++ b/src/main/java/flab/rocket_market/aop/AuthorizationAspect.java
@@ -1,8 +1,8 @@
 package flab.rocket_market.aop;
 
-import flab.rocket_market.dto.User;
-import flab.rocket_market.exception.AccessDeniedException;
-import flab.rocket_market.service.UserService;
+import flab.rocket_market.users.dto.User;
+import flab.rocket_market.users.exception.AccessDeniedException;
+import flab.rocket_market.users.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;

--- a/src/main/java/flab/rocket_market/users/exception/AccessDeniedException.java
+++ b/src/main/java/flab/rocket_market/users/exception/AccessDeniedException.java
@@ -1,0 +1,13 @@
+package flab.rocket_market.users.exception;
+
+import flab.rocket_market.users.exception.error.SecurityErrorProperty;
+import flab.rocket_market.global.exception.RocketMarketException;
+
+public class AccessDeniedException extends RocketMarketException {
+
+    public static final AccessDeniedException EXCEPTION = new AccessDeniedException();
+
+    private AccessDeniedException() {
+        super(SecurityErrorProperty.ACCESS_DENIED_EXCEPTION);
+    }
+}

--- a/src/main/java/flab/rocket_market/users/exception/UserNotFoundException.java
+++ b/src/main/java/flab/rocket_market/users/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package flab.rocket_market.users.exception;
+
+import flab.rocket_market.users.exception.error.UserErrorProperty;
+import flab.rocket_market.global.exception.RocketMarketException;
+
+public class UserNotFoundException extends RocketMarketException {
+
+    public static final UserNotFoundException EXCEPTION = new UserNotFoundException();
+
+    private UserNotFoundException() {
+        super(UserErrorProperty.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/flab/rocket_market/users/exception/error/UserErrorProperty.java
+++ b/src/main/java/flab/rocket_market/users/exception/error/UserErrorProperty.java
@@ -1,0 +1,16 @@
+package flab.rocket_market.users.exception.error;
+
+import flab.rocket_market.global.exception.error.ErrorProperty;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorProperty implements ErrorProperty {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}


### PR DESCRIPTION
## PR 개요
users 패키지 생성 후 관련 클래스 이동

## 🔨 변경 내용
- users 패키지 생성 후 관련 클래스 이동

- 최종 변경 후 예상 구조
src/main/java/flab/rocket_market
│
├── products
│ ├── controller
│ ├── service
│ ├── repository
│ ├── dto
│ ├── entity
│ └── exception
│
├── orders
│ ├── controller
│ ├── service
│ ├── repository
│ ├── dto
│ ├── entity
│ └── exception
│
└── users
├── controller
├── service
├── repository
├── dto
├── entity
└── exception

## 📌 Issues
