### PR TITLE
[#77] ProductsSearchService 테스트 코드 작성 (2)

### DIFF
--- a/src/main/java/flab/rocket_market/global/message/MessageConstants.java
+++ b/src/main/java/flab/rocket_market/global/message/MessageConstants.java
@@ -11,6 +11,7 @@ public enum MessageConstants {
     PRODUCT_RETRIEVE_SUCCESS("성공적으로 조회되었습니다."),
     PRODUCT_UPDATE_SUCCESS("성공적으로 수정되었습니다"),
     PRODUCT_DELETE_SUCCESS("성공적으로 삭제되었습니다."),
+    PRODUCT_SEARCH_FAILED("상품 검색에 실패하였습니다."),
 
     ORDER_CREATE_SUCCESS("주문에 성공하였습니다."),
 

--- a/src/main/java/flab/rocket_market/products/exception/ProductSearchException.java
+++ b/src/main/java/flab/rocket_market/products/exception/ProductSearchException.java
@@ -1,0 +1,13 @@
+package flab.rocket_market.products.exception;
+
+import flab.rocket_market.global.exception.RocketMarketException;
+import flab.rocket_market.products.exception.error.ProductErrorProperty;
+
+public class ProductSearchException extends RocketMarketException {
+
+    public static final ProductSearchException EXCEPTION = new ProductSearchException();
+
+    private ProductSearchException() {
+        super(ProductErrorProperty.PRODUCT_SEARCH_EXCEPTION);
+    }
+}

--- a/src/main/java/flab/rocket_market/products/exception/error/ProductErrorProperty.java
+++ b/src/main/java/flab/rocket_market/products/exception/error/ProductErrorProperty.java
@@ -6,12 +6,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 import static flab.rocket_market.global.message.MessageConstants.PRODUCT_NOT_FOUND;
+import static flab.rocket_market.global.message.MessageConstants.PRODUCT_SEARCH_FAILED;
 
 @Getter
 @RequiredArgsConstructor
 public enum ProductErrorProperty implements ErrorProperty {
 
-    PRODUCT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, PRODUCT_NOT_FOUND.getMessage());
+    PRODUCT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, PRODUCT_NOT_FOUND.getMessage()),
+    PRODUCT_SEARCH_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, PRODUCT_SEARCH_FAILED.getMessage());
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## PR 개요
Elasticsearch 검색 오류 및 테스트 코드 작성

## 🔨 변경 내용
- Elasticsearch 검색 관련 예외 클래스 생성
- searchProductsFromElasticsearch 예외 발생을 대비한 try catch 구문 추가
- 해당 예외케이스와 관련된 테스트 코드 추가

## 📌 Issues
