### PR TITLE
[#76] Order API 관련 피드백 반영 (1)

### DIFF
--- a/src/main/java/flab/rocket_market/orders/entity/Payment.java
+++ b/src/main/java/flab/rocket_market/orders/entity/Payment.java
@@ -37,4 +37,8 @@ public class Payment {
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
+
+    public void failedPayment() {
+        this.status = false;
+    }
 }

--- a/src/main/java/flab/rocket_market/orders/exception/OrderFailedException.java
+++ b/src/main/java/flab/rocket_market/orders/exception/OrderFailedException.java
@@ -1,0 +1,13 @@
+package flab.rocket_market.orders.exception;
+
+import flab.rocket_market.global.exception.RocketMarketException;
+import flab.rocket_market.orders.exception.error.OrderErrorProperty;
+
+public class OrderFailedException extends RocketMarketException {
+
+    public static final OrderFailedException EXCEPTION = new OrderFailedException();
+
+    public OrderFailedException() {
+        super(OrderErrorProperty.ORDER_FAILED_EXCEPTION);
+    }
+}

--- a/src/main/java/flab/rocket_market/orders/exception/PaymentNotFoundException.java
+++ b/src/main/java/flab/rocket_market/orders/exception/PaymentNotFoundException.java
@@ -1,0 +1,13 @@
+package flab.rocket_market.orders.exception;
+
+import flab.rocket_market.global.exception.RocketMarketException;
+import flab.rocket_market.orders.exception.error.OrderErrorProperty;
+
+public class PaymentNotFoundException extends RocketMarketException {
+
+    public static final PaymentNotFoundException EXCEPTION = new PaymentNotFoundException();
+
+    public PaymentNotFoundException() {
+        super(OrderErrorProperty.PAYMENT_NOT_FOUND_EXCEPTION);
+    }
+}

--- a/src/main/java/flab/rocket_market/orders/exception/error/OrderErrorProperty.java
+++ b/src/main/java/flab/rocket_market/orders/exception/error/OrderErrorProperty.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum OrderErrorProperty implements ErrorProperty {
 
     OUT_OF_STOCK_EXCEPTION(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
-    PAYMENT_PROCESSING_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "결제에 실패하였습니다.");
+    PAYMENT_PROCESSING_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "결제 API 호출에 실패하였습니다."),
+    PAYMENT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "결제 정보가 없습니다."),
+    ORDER_FAILED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "주문 데이터 저장에 실패하였습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/flab/rocket_market/orders/service/PaymentService.java
+++ b/src/main/java/flab/rocket_market/orders/service/PaymentService.java
@@ -1,7 +1,9 @@
 package flab.rocket_market.orders.service;
 
 import flab.rocket_market.orders.dto.PaymentRequest;
+import flab.rocket_market.orders.dto.PaymentResponse;
 import flab.rocket_market.orders.entity.Payment;
+import flab.rocket_market.orders.exception.PaymentNotFoundException;
 import flab.rocket_market.orders.exception.PaymentProcessingException;
 import flab.rocket_market.orders.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,19 @@ public class PaymentService {
                 .build());
 
         return payment;
+    }
+
+    public void cancelPayment(PaymentResponse paymentResponse) {
+        boolean isSuccessful = callPaymentAPI();
+
+        if (!isSuccessful) {
+            throw PaymentProcessingException.EXCEPTION;
+        }
+
+        Payment payment = paymentRepository.findById(paymentResponse.getPaymentId())
+                .orElseThrow(() -> PaymentNotFoundException.EXCEPTION);
+
+        payment.failedPayment();
     }
 
     /**


### PR DESCRIPTION
## PR 개요
주문 데이터 저장 관련 예외 추가

## 🔨 변경 내용
- 결제 정보가 없을 경우 예외
- 주문 정보 저장에 실패했을 경우 예외
- 결제 정보 상태 업데이트 메서드 추가

## 📌 Issues